### PR TITLE
Repoint config to correct database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,16 +5,16 @@ default: &default
 
 development:
   <<: *default
-  database: content_performance_manager_development
+  database: content_audit_tool_development
   url: <%= ENV['DEVELOPMENT_DATABASE_URL'] || ENV['DATABASE_URL'] %>
 
 test:
   <<: *default
-  database: content_performance_manager_test
+  database: content_audit_tool_test
   url: <%= ENV['TEST_DATABASE_URL'] || ENV['DATABASE_URL'] %>
 
 production:
   <<: *default
-  database: content_performance_manager_production
-  username: content_performance_manager
-  password: <%= ENV['CONTENT-PERFORMANCE-MANAGER_DATABASE_PASSWORD'] %>
+  database: content_audit_tool_production
+  username: content_audit_tool
+  password: <%= ENV['CONTENT-AUDIT-TOOL_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
As I need to test importing data from Content Performance Manager into the Content Audit Tool, I need the database configs to be correct in the master branch. This is because the master branch of the Content Audit Tool is still in sync with the Content Performance Manager and allows us to do the data migration.