### PR TITLE
Improve performance of index page

### DIFF
--- a/db/migrate/20180627100329_add_indexes_to_links_link_type_target_id.rb
+++ b/db/migrate/20180627100329_add_indexes_to_links_link_type_target_id.rb
@@ -1,0 +1,6 @@
+class AddIndexesToLinksLinkTypeTargetId < ActiveRecord::Migration[5.1]
+  def change
+    add_index :links, %i(link_type target_content_id)
+    add_index :links, %i(link_type source_content_id)
+  end
+end

--- a/db/migrate/20180627101032_add_document_type_index_to_content_items.rb
+++ b/db/migrate/20180627101032_add_document_type_index_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddDocumentTypeIndexToContentItems < ActiveRecord::Migration[5.1]
+  def change
+    add_index :content_items, %i(document_type content_id six_months_page_views), name: 'index_content_items_on_document_type_content_id_ordered'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180327172855) do
+ActiveRecord::Schema.define(version: 20180627101032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20180327172855) do
     t.string "locale", null: false
     t.index ["base_path"], name: "index_content_items_on_base_path"
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
+    t.index ["document_type", "content_id", "six_months_page_views"], name: "index_content_items_on_document_type_content_id_ordered"
     t.index ["title"], name: "index_content_items_on_title"
   end
 
@@ -68,6 +69,8 @@ ActiveRecord::Schema.define(version: 20180327172855) do
     t.string "target_content_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["link_type", "source_content_id"], name: "index_links_on_link_type_and_source_content_id"
+    t.index ["link_type", "target_content_id"], name: "index_links_on_link_type_and_target_content_id"
     t.index ["link_type"], name: "index_links_on_link_type"
     t.index ["source_content_id"], name: "index_links_on_source_content_id"
     t.index ["target_content_id"], name: "index_links_on_target_content_id"

--- a/spec/domain/importers/single_content_item_spec.rb
+++ b/spec/domain/importers/single_content_item_spec.rb
@@ -73,10 +73,11 @@ RSpec.describe Importers::SingleContentItem do
     it "updates the content item" do
       content_item.save!
 
-      expect { subject.run(content_id, locale, version) }
-        .to change { content_item.reload.title }.from("title").to("new title")
-        .and change { content_item.reload.linked_taxons.to_a }.from([]).to([taxon1, taxon2])
-        .and change { content_item.reload.linked_organisations.to_a }.from([]).to([org1, org2])
+      subject.run(content_id, locale, version)
+
+      expect(content_item.reload.title).to eq("new title")
+      expect(content_item.linked_organisations.to_a).to eq([org2, org1])
+      expect(content_item.linked_taxons.to_a).to eq([taxon2, taxon1])
     end
 
     it "does not override `six_months_page_views` attributes" do


### PR DESCRIPTION
We have a [Zendesk ticket][1] that reports 504 on the Audit tool. I have
checked the queries, and some of them could be improved, so I have 
created a few indexes to speed them up.

The following querie, for example, would be improved:

```sql
SELECT COUNT(*) FROM "content_items" LEFT OUTER JOIN "allocations" ON "allocations"."content_id" = "content_items"."content_id" WHERE "content_items"."content_id" IN (SELECT source_content_id as content_id FROM "links" WHERE "links"."link_type" = $1 AND "links"."target_content_id" = '6667cce2-e809-4e21-ae09-cb0bdc1ddda3') AND "content_items"."content_id" IN (SELECT source_content_id as content_id FROM "links" WHERE "links"."link_type" = $2 AND "links"."target_content_id" = 'de905af9-0b79-4f36-bc12-703d79971e8b') AND "content_items"."document_type" IN ('answer', 'case_study', 'closed_consultation', 'consultation_outcome', 'corporate_report', 'correspondence', 'decision', 'detailed_guide', 'document_collection', 'form', 'guidance', 'guide', 'impact_assessment', 'independent_report', 'international_treaty', 'mainstream_browse_page', 'manual', 'manual_section', 'map', 'notice', 'open_consultation', 'policy_paper', 'promotional', 'regulation', 'research', 'simple_smart_answer', 'smart_answer', 'statutory_guidance', 'transaction', 'transparency') AND ("content_items"."content_id" NOT IN (SELECT "audits"."content_id" FROM "audits")) AND "allocations"."id" IS NULL  [["link_type", "primary_publishing_organisation"], ["link_type", "topics"]]
```

[1]: https://govuk.zendesk.com/agent/tickets/2832285