### PR TITLE
Reduce pagination size for PublishingAPI

### DIFF
--- a/app/services/clients/publishing_api.rb
+++ b/app/services/clients/publishing_api.rb
@@ -2,7 +2,7 @@ require 'gds_api/publishing_api_v2'
 
 module Clients
   class PublishingAPI
-    PER_PAGE = 700
+    PER_PAGE = 100
 
     attr_accessor :publishing_api, :per_page
 
@@ -12,7 +12,7 @@ module Clients
         disable_cache: true,
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
       )
-      @per_page = 700
+      @per_page = 100
     end
 
     def fetch_all(fields)

--- a/spec/services/clients/publishing_api_spec.rb
+++ b/spec/services/clients/publishing_api_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Clients::PublishingAPI do
 
   describe "#all_content_items" do
     describe "multiple pages of 'en' content items" do
-      let(:page_size) { 700 }
+      let(:page_size) { 100 }
 
       let(:content_ids) { (page_size + 1).times.map { |i| "id-#{i}" } }
 


### PR DESCRIPTION
We are having 504 from PublishingAPI that prevent the Audit Tool from
updating its data on a daily basis.