### PR TITLE
Revert "Remove left outer join from Finding unallocated items"

### DIFF
--- a/app/domain/policies/unallocated.rb
+++ b/app/domain/policies/unallocated.rb
@@ -1,7 +1,7 @@
 module Policies
   class Unallocated
     def self.call(scope, allocated_to: nil) # rubocop:disable Lint/UnusedMethodArgument
-      scope.where('content_items.content_id not in (select content_id from allocations)')
+      scope.left_joins(:allocation).where(allocations: { id: nil })
     end
   end
 end


### PR DESCRIPTION
Reverts alphagov/content-audit-tool#100

It is not working as expected