### PR TITLE
Remove left outer join from Finding unallocated items

### DIFF
--- a/app/domain/policies/unallocated.rb
+++ b/app/domain/policies/unallocated.rb
@@ -1,7 +1,7 @@
 module Policies
   class Unallocated
     def self.call(scope, allocated_to: nil) # rubocop:disable Lint/UnusedMethodArgument
-      scope.left_joins(:allocation).where(allocations: { id: nil })
+      scope.where('content_items.content_id not in (select content_id from allocations)')
     end
   end
 end


### PR DESCRIPTION
The database was degraded because of an issue with 
a different application. I am merging it again so it can 
be tested in real conditions.