### PR TITLE
Set rubyLintDiff to false in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node {
   govuk.buildProject(
+    rubyLintDiff: false,
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     }


### PR DESCRIPTION
To ensure all the code is checked.