### PR TITLE
Add an index on document_type for content_items

### DIFF
--- a/db/migrate/20180906152643_add_index_to_content_items_document_type.rb
+++ b/db/migrate/20180906152643_add_index_to_content_items_document_type.rb
@@ -1,0 +1,7 @@
+class AddIndexToContentItemsDocumentType < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :content_items, :document_type, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180627101032) do
+ActiveRecord::Schema.define(version: 20180906152643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20180627101032) do
     t.index ["base_path"], name: "index_content_items_on_base_path"
     t.index ["content_id"], name: "index_content_items_on_content_id", unique: true
     t.index ["document_type", "content_id", "six_months_page_views"], name: "index_content_items_on_document_type_content_id_ordered"
+    t.index ["document_type"], name: "index_content_items_on_document_type"
     t.index ["title"], name: "index_content_items_on_title"
   end
 


### PR DESCRIPTION
This is used in a query to count the number of content items and the current 3-way index can't be used as the other fields aren't present in the query. It takes the running time down from 15 seconds to under 500 ms. It also stops the application from timing out the first time you go to it.

[Trello Card](https://trello.com/c/VztlS695/447-investigate-options-for-reducing-load-on-the-production-postgres-primary)