### PR TITLE
Use joins instead of IN and NOT IN

### DIFF
--- a/app/domain/policies/allocated.rb
+++ b/app/domain/policies/allocated.rb
@@ -1,7 +1,7 @@
 module Policies
   class Allocated
     def self.call(scope, allocated_to:)
-      scope.joins(:allocation).where('allocations.uid = ?', allocated_to)
+      scope.joins(:allocation).where(allocations: { uid: allocated_to })
     end
   end
 end

--- a/app/domain/policies/failed.rb
+++ b/app/domain/policies/failed.rb
@@ -1,7 +1,7 @@
 module Policies
   class Failed
     def self.call(scope)
-      scope.where(content_id: Audit.failing.select(:content_id))
+      scope.joins(:audit).merge(Audit.failing)
     end
   end
 end

--- a/app/domain/policies/non_audited.rb
+++ b/app/domain/policies/non_audited.rb
@@ -1,7 +1,11 @@
 module Policies
   class NonAudited
     def self.call(scope)
-      scope.where.not(content_id: Audit.all.select(:content_id))
+      unless scope.joins_values.include?(:audit)
+        scope = scope.left_outer_joins(:audit)
+      end
+
+      scope.where(audits: { content_id: nil })
     end
   end
 end

--- a/app/domain/policies/passed.rb
+++ b/app/domain/policies/passed.rb
@@ -1,7 +1,7 @@
 module Policies
   class Passed
     def self.call(scope)
-      scope.where(content_id: Audit.passing.select(:content_id))
+      scope.joins(:audit).merge(Audit.passing)
     end
   end
 end

--- a/app/domain/policies/unallocated.rb
+++ b/app/domain/policies/unallocated.rb
@@ -1,7 +1,7 @@
 module Policies
   class Unallocated
     def self.call(scope, allocated_to: nil) # rubocop:disable Lint/UnusedMethodArgument
-      scope.where('content_items.content_id not in (select content_id from allocations)')
+      scope.left_outer_joins(:allocation).where(allocations: { content_id: nil })
     end
   end
 end


### PR DESCRIPTION
This has significant performance improvements as it avoids having to execute multiple subqueries for each row.

[Trello Card](https://trello.com/c/VztlS695/447-investigate-options-for-reducing-load-on-the-production-postgres-primary)