### PR TITLE
Passes custom tag to sidekiq to override process name

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-publishing-api-worker: bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml
-google-analytics-worker: bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml
+publishing-api-worker: bundle exec sidekiq -C ./config/sidekiq/publishing_api.yml --tag content-audit-tool/publishing-api-worker
+google-analytics-worker: bundle exec sidekiq -C ./config/sidekiq/google_analytics.yml --tag content-audit-tool/google-analytics-worker
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}


### PR DESCRIPTION
Trello card: https://trello.com/c/r4s5HkdF/

We've had to pass a custom '--tag' to sidekiq so that it names our
process. Previously, process would simply be 'sidekiq 5.2.5 content-audit-tool [0 of x]',
which doesn't tell us which of the workers it is.

Now, output will be 'sidekiq 5.2.5 content-audit-tool/google-analytics-worker [0 of x]'
(for example), which gives us a very regexable process name.

We can therefore fix the Icinga link.

To be merged with https://github.com/alphagov/govuk-puppet/pull/9221.